### PR TITLE
Characters are changed only within a table.

### DIFF
--- a/org-pretty-table.el
+++ b/org-pretty-table.el
@@ -41,119 +41,137 @@ between START and END.
 Used by jit-lock for dynamic highlighting."
   (save-excursion
     (goto-char start)
-    (while (re-search-forward org-pretty-table-regexp end t)
-      ;; determine the context of the character
-      (let ((match (match-string 0)))
-        (cond
-         ((equal "-" match)
-          (backward-char 1)
-          (re-search-forward "-+")
-          (put-text-property (match-beginning 0) (match-end 0) 'display (make-string (- (match-end 0) (match-beginning 0)) ?─))
-          t)
-         ((equal "|" match)
-          (cond
-           ((and (eq (following-char) ?-)
-                 (save-excursion
-                   (forward-line 1)
-                   (not (org-pretty-table-is-empty-line)))
-                 (save-excursion
-                   (forward-line -1)
-                   (not (org-pretty-table-is-empty-line))))
-            (put-text-property (match-beginning 0) (match-end 0) 'display "├")
-            t)
-           ((and (save-excursion
-                   (backward-char 1)
-                   (eq (preceding-char) ?-))
-                 (save-excursion
-                   (forward-line 1)
-                   (not (org-pretty-table-is-empty-line)))
-                 (save-excursion
-                   (forward-line -1)
-                   (not (org-pretty-table-is-empty-line))))
-            (put-text-property (match-beginning 0) (match-end 0) 'display "┤")
-            t)
-           ((and (save-excursion
-                   (backward-char 1)
-                   (eq (preceding-char) ?-))
-                 (save-excursion
-                   (forward-line -1)
-                   (org-pretty-table-is-empty-line)))
-            (put-text-property (match-beginning 0) (match-end 0) 'display "┐")
-            t)
-           ((and (save-excursion
-                   (backward-char 1)
-                   (eq (preceding-char) ?-))
-                 (save-excursion
-                   (forward-line 1)
-                   (org-pretty-table-is-empty-line)))
-            (put-text-property (match-beginning 0) (match-end 0) 'display "┘")
-            t)
-           ((and (eq (following-char) ?-)
-                 (save-excursion
-                   (forward-line -1)
-                   (org-pretty-table-is-empty-line)))
-            (put-text-property (match-beginning 0) (match-end 0) 'display "┌")
-            t)
-           ((and (eq (following-char) ?-)
-                 (save-excursion
-                   (forward-line 1)
-                   (org-pretty-table-is-empty-line)))
-            (put-text-property (match-beginning 0) (match-end 0) 'display "└")
-            t)
-           (t
-            (put-text-property (match-beginning 0) (match-end 0) 'display "│")
-            t)))
-         ((equal "+" match)
-          (cond
-           ((and (eq (following-char) ?-)
-                 (save-excursion
-                   (backward-char 1)
-                   (eq (preceding-char) ?-))
-                 (save-excursion
-                   (let ((char-pos (- (point) (line-beginning-position) 1)))
-                     (forward-line -1)
-                     (beginning-of-line)
-                     (forward-char char-pos))
-                   (eq (following-char) ?|))
-                 (save-excursion
-                   (backward-char 1)
-                   (next-line)
-                   (eq (following-char) ?|)))
-            (put-text-property (match-beginning 0) (match-end 0) 'display "┼")
-            t)
-           ((and (eq (following-char) ?-)
-                 (save-excursion
-                   (backward-char 1)
-                   (eq (preceding-char) ?-))
-                 (save-excursion
-                   (backward-char 1)
-                   (previous-line)
-                   (memq (following-char) '(? 10)))
-                 (save-excursion
-                   (let ((char-pos (- (point) (line-beginning-position) 1)))
-                     (forward-line 1)
-                     (beginning-of-line)
-                     (forward-char char-pos))
-                   (eq (following-char) ?|)))
-            (put-text-property (match-beginning 0) (match-end 0) 'display "┬")
-            t)
-           ((and (eq (following-char) ?-)
-                 (save-excursion
-                   (backward-char 1)
-                   (eq (preceding-char) ?-))
-                 (save-excursion
-                   (let ((char-pos (- (point) (line-beginning-position) 1)))
-                     (forward-line -1)
-                     (beginning-of-line)
-                     (forward-char char-pos))
-                   (eq (following-char) ?|))
-                 (save-excursion
-                   (backward-char 1)
-                   (next-line)
-                   (or (memq (following-char) '(? 10))
-                       (eq (char-after (line-beginning-position)) ?#))))
-            (put-text-property (match-beginning 0) (match-end 0) 'display "┴")
-            t))))))))
+    (let (table-end)
+      (while (re-search-forward org-pretty-table-regexp end t)
+        ;; reached the end of the current table
+        (if (and table-end
+                 (> (point) table-end))
+            (setq table-end nil))
+
+        ;; check if the current match is a table if we are not in a
+        ;; table right now
+        (unless (and (not table-end)
+                     (not (save-match-data
+                            (org-at-table-p))))
+
+          ;; get the end of the table if we found a new table, so we
+          ;; don't have to check (org-at-table-p) again until then
+          (unless table-end
+            (save-match-data
+              (setq table-end (org-table-end))))
+          
+          ;; determine the context of the character
+          (let ((match (match-string 0)))
+            (cond
+             ((equal "-" match)
+              (backward-char 1)
+              (re-search-forward "-+")
+              (put-text-property (match-beginning 0) (match-end 0) 'display (make-string (- (match-end 0) (match-beginning 0)) ?─))
+              t)
+             ((equal "|" match)
+              (cond
+               ((and (eq (following-char) ?-)
+                     (save-excursion
+                       (forward-line 1)
+                       (not (org-pretty-table-is-empty-line)))
+                     (save-excursion
+                       (forward-line -1)
+                       (not (org-pretty-table-is-empty-line))))
+                (put-text-property (match-beginning 0) (match-end 0) 'display "├")
+                t)
+               ((and (save-excursion
+                       (backward-char 1)
+                       (eq (preceding-char) ?-))
+                     (save-excursion
+                       (forward-line 1)
+                       (not (org-pretty-table-is-empty-line)))
+                     (save-excursion
+                       (forward-line -1)
+                       (not (org-pretty-table-is-empty-line))))
+                (put-text-property (match-beginning 0) (match-end 0) 'display "┤")
+                t)
+               ((and (save-excursion
+                       (backward-char 1)
+                       (eq (preceding-char) ?-))
+                     (save-excursion
+                       (forward-line -1)
+                       (org-pretty-table-is-empty-line)))
+                (put-text-property (match-beginning 0) (match-end 0) 'display "┐")
+                t)
+               ((and (save-excursion
+                       (backward-char 1)
+                       (eq (preceding-char) ?-))
+                     (save-excursion
+                       (forward-line 1)
+                       (org-pretty-table-is-empty-line)))
+                (put-text-property (match-beginning 0) (match-end 0) 'display "┘")
+                t)
+               ((and (eq (following-char) ?-)
+                     (save-excursion
+                       (forward-line -1)
+                       (org-pretty-table-is-empty-line)))
+                (put-text-property (match-beginning 0) (match-end 0) 'display "┌")
+                t)
+               ((and (eq (following-char) ?-)
+                     (save-excursion
+                       (forward-line 1)
+                       (org-pretty-table-is-empty-line)))
+                (put-text-property (match-beginning 0) (match-end 0) 'display "└")
+                t)
+               (t
+                (put-text-property (match-beginning 0) (match-end 0) 'display "│")
+                t)))
+             ((equal "+" match)
+              (cond
+               ((and (eq (following-char) ?-)
+                     (save-excursion
+                       (backward-char 1)
+                       (eq (preceding-char) ?-))
+                     (save-excursion
+                       (let ((char-pos (- (point) (line-beginning-position) 1)))
+                         (forward-line -1)
+                         (beginning-of-line)
+                         (forward-char char-pos))
+                       (eq (following-char) ?|))
+                     (save-excursion
+                       (backward-char 1)
+                       (next-line)
+                       (eq (following-char) ?|)))
+                (put-text-property (match-beginning 0) (match-end 0) 'display "┼")
+                t)
+               ((and (eq (following-char) ?-)
+                     (save-excursion
+                       (backward-char 1)
+                       (eq (preceding-char) ?-))
+                     (save-excursion
+                       (backward-char 1)
+                       (previous-line)
+                       (memq (following-char) '(? 10)))
+                     (save-excursion
+                       (let ((char-pos (- (point) (line-beginning-position) 1)))
+                         (forward-line 1)
+                         (beginning-of-line)
+                         (forward-char char-pos))
+                       (eq (following-char) ?|)))
+                (put-text-property (match-beginning 0) (match-end 0) 'display "┬")
+                t)
+               ((and (eq (following-char) ?-)
+                     (save-excursion
+                       (backward-char 1)
+                       (eq (preceding-char) ?-))
+                     (save-excursion
+                       (let ((char-pos (- (point) (line-beginning-position) 1)))
+                         (forward-line -1)
+                         (beginning-of-line)
+                         (forward-char char-pos))
+                       (eq (following-char) ?|))
+                     (save-excursion
+                       (backward-char 1)
+                       (next-line)
+                       (or (memq (following-char) '(? 10))
+                           (eq (char-after (line-beginning-position)) ?#))))
+                (put-text-property (match-beginning 0) (match-end 0) 'display "┴")
+                t))))))))))
 
 (defun org-pretty-table-unpropertize-region (start end)
   "Remove box-drawing compositions between START and END."


### PR DESCRIPTION
Thanks for merging the previous PR, here's one more (the last, I don't plan to do more) which fixes the other issue in https://github.com/Fuco1/org-pretty-table/issues/2 ("changes hyphens - for the entire buffer, not just tables").

Unfortunately, unlike diff in emacs, github's diff is not able the highlight only the actually changed lines, ignoring whitespace changes, so I copy here the relevant change for easier review.

It calls `(org-at-table-p)` to check if we are in a table, but it would be senseless to call this for every character in the table, so if we find a table then the end position of the table is stored and `(org-at-table-p)` is not called again until search position leaves the current table:

    (let (table-end)
      (while (re-search-forward org-pretty-table-regexp end t)
        ;; reached the end of the current table
        (if (and table-end
                 (> (point) table-end))
            (setq table-end nil))

        ;; check if the current match is a table if we are not in a
        ;; table right now
        (unless (and (not table-end)
                     (not (save-match-data
                            (org-at-table-p))))

          ;; get the end of the table if we found a new table, so we
          ;; don't have to check (org-at-table-p) again until then
          (unless table-end
            (save-match-data
              (setq table-end (org-table-end))))

          ...        